### PR TITLE
Add built-in video playback

### DIFF
--- a/ultrasonic/src/main/AndroidManifest.xml
+++ b/ultrasonic/src/main/AndroidManifest.xml
@@ -68,6 +68,11 @@
                 android:resource="@xml/searchable"/>
         </activity>
 
+        <activity
+            android:name=".activity.VideoPlaybackActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:exported="false" />
+
         <service
             android:name=".service.DownloadService"
             android:label="Ultrasonic Media Player Service"

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/VideoPlaybackActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/VideoPlaybackActivity.kt
@@ -1,0 +1,50 @@
+/*
+ * VideoPlaybackActivity.kt
+ * Copyright (C) 2009-2023 Ultrasonic developers
+ *
+ * Distributed under terms of the GNU GPLv3 license.
+ */
+
+package org.moire.ultrasonic.activity
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import org.moire.ultrasonic.R
+
+/**
+ * Simple activity used to play video content using ExoPlayer.
+ */
+class VideoPlaybackActivity : AppCompatActivity() {
+
+    private var player: ExoPlayer? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_video_playback)
+
+        val url = intent.getStringExtra(EXTRA_URL)
+        val view = findViewById<PlayerView>(R.id.video_view)
+
+        if (url != null) {
+            player = ExoPlayer.Builder(this).build().also { exoPlayer ->
+                view.player = exoPlayer
+                exoPlayer.setMediaItem(MediaItem.fromUri(url))
+                exoPlayer.prepare()
+                exoPlayer.playWhenReady = true
+            }
+        }
+    }
+
+    override fun onStop() {
+        player?.release()
+        player = null
+        super.onStop()
+    }
+
+    companion object {
+        const val EXTRA_URL = "EXTRA_URL"
+    }
+}

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/VideoPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/VideoPlayer.kt
@@ -2,7 +2,7 @@ package org.moire.ultrasonic.subsonic
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
+import org.moire.ultrasonic.activity.VideoPlaybackActivity
 import org.moire.ultrasonic.R
 import org.moire.ultrasonic.domain.Track
 import org.moire.ultrasonic.service.MusicServiceFactory
@@ -20,16 +20,13 @@ class VideoPlayer {
                 return
             }
             try {
-                val intent = Intent(Intent.ACTION_VIEW)
                 val url = MusicServiceFactory.getMusicService().getStreamUrl(
                     track.id,
                     maxBitRate = null,
                     format = "raw"
                 )
-                intent.setDataAndType(
-                    Uri.parse(url),
-                    "video/*"
-                )
+                val intent = Intent(context, VideoPlaybackActivity::class.java)
+                intent.putExtra(VideoPlaybackActivity.EXTRA_URL, url)
                 context.startActivity(intent)
             } catch (all: Exception) {
                 Util.toast(all.toString(), false, context)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/DownloadUtil.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/DownloadUtil.kt
@@ -112,9 +112,7 @@ object DownloadUtil {
             return
         }
         for (song in parent.getTracks()) {
-            if (!song.isVideo) {
-                songs.add(song)
-            }
+            songs.add(song)
         }
         val musicService = MusicServiceFactory.getMusicService()
         for ((id1, _, _, title) in parent.getAlbums()) {
@@ -139,9 +137,7 @@ object DownloadUtil {
                 false
             )
             for (song in albumDirectory.getTracks()) {
-                if (!song.isVideo) {
-                    songs.add(song)
-                }
+                songs.add(song)
             }
         }
         return songs

--- a/ultrasonic/src/main/res/layout/activity_video_playback.xml
+++ b/ultrasonic/src/main/res/layout/activity_video_playback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:a="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    a:layout_width="match_parent"
+    a:layout_height="match_parent">
+
+    <androidx.media3.ui.PlayerView
+        a:id="@+id/video_view"
+        a:layout_width="match_parent"
+        a:layout_height="match_parent"
+        app:show_buffering="when_playing" />
+</FrameLayout>


### PR DESCRIPTION
## Summary
- add a VideoPlaybackActivity that uses ExoPlayer
- launch the new activity from `VideoPlayer`
- allow downloading videos by removing the video filter in `DownloadUtil`
- register the new activity in the manifest
- add layout for the player

## Testing
- `./gradlew -Pqc ktlintCheck` *(fails: No such property: ktlint)*
- `./gradlew -Pqc detekt` *(fails: No such property: ktlint)*
- `./gradlew :ultrasonic:lintRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686906b529ac83268f155d4ff61fe17e