### PR TITLE
Add toast when switching to offline mode

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
@@ -113,6 +113,12 @@ class ActiveServerProvider(
         val oldServerId = Settings.activeServer
         if (oldServerId == serverId) return
 
+        if (oldServerId != OFFLINE_DB_ID && serverId == OFFLINE_DB_ID) {
+            Util.toast(R.string.server_switched_offline, true, UApp.applicationContext())
+        } else if (oldServerId == OFFLINE_DB_ID && serverId != OFFLINE_DB_ID) {
+            Util.toast(R.string.server_switched_online, true, UApp.applicationContext())
+        }
+
         // Notify components about the change before actually resetting the MusicService
         // so they can react by e.g. stopping playback on the old server
         RxBus.activeServerChangingPublisher.onNext(oldServerId)

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -138,6 +138,8 @@
     <string name="main.landing_page_title">Home</string>
     <string name="main.livesets">livesets</string>
     <string name="main.offline">Offline</string>
+    <string name="server_switched_offline">Server unreachable. Switched to offline mode.</string>
+    <string name="server_switched_online">Server reachable. Online mode restored.</string>
     <string name="main.setup_server">%s - Set up Server</string>
     <string name="main.songs_random">Random</string>
     <string name="main.songs_random_this_year">Random (2025)</string>


### PR DESCRIPTION
## Summary
- notify user when switching to offline server
- add `server_switched_offline` string resource
- show toast when switching back to online server

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ae2e2b5c8326a6560bbccc6618a3