### PR TITLE
Fix playlist refresh loop

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/JukeboxMediaPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/JukeboxMediaPlayer.kt
@@ -70,6 +70,11 @@ class JukeboxMediaPlayer : JukeboxUnimplementedFunctions(), Player {
 
     private var listeners: ListenerSet<Player.Listener>
     private val playlist: MutableList<MediaItem> = mutableListOf()
+    /**
+     * Last playlist that was sent to listeners and the remote jukebox.
+     * Helps to avoid unnecessary events on timeline changes.
+     */
+    private var lastPublishedPlaylist: List<MediaItem>? = null
 
     private var _currentIndex: Int = 0
     private var currentIndex: Int
@@ -584,6 +589,11 @@ class JukeboxMediaPlayer : JukeboxUnimplementedFunctions(), Player {
 
     private fun updatePlaylist() {
         if (!running.get()) return
+        // Avoid unnecessary remote calls and UI refreshes when the playlist has
+        // not actually changed.
+        val currentList = playlist.toList()
+        if (currentList == lastPublishedPlaylist) return
+        lastPublishedPlaylist = currentList
         tasks.remove(Skip::class.java)
         tasks.remove(Stop::class.java)
         tasks.remove(Start::class.java)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerManager.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerManager.kt
@@ -106,7 +106,10 @@ class MediaPlayerManager(
                 deferredPlay = null
             }
             val playlist = Util.getPlayListFromTimeline(timeline, false).map(MediaItem::toTrack)
-            RxBus.playlistPublisher.onNext(playlist)
+            if (playlist != lastPublishedPlaylist) {
+                lastPublishedPlaylist = playlist
+                RxBus.playlistPublisher.onNext(playlist)
+            }
         }
 
         override fun onPlaybackStateChanged(playbackState: Int) {
@@ -175,6 +178,13 @@ class MediaPlayerManager(
     private var deferredPlay: (() -> Unit)? = null
 
     private var cachedMediaItem: MediaItem? = null
+
+    /**
+     * Cache the last playlist that was published via [RxBus].
+     * This helps to avoid redundant updates which would refresh the UI
+     * unnecessarily.
+     */
+    private var lastPublishedPlaylist: List<Track>? = null
 
     fun onCreate(onCreated: () -> Unit) {
         if (created) return


### PR DESCRIPTION
## Summary
- avoid re-sending playlist when MediaPlayer timeline hasn't changed
- skip jukebox updates when playlist is unchanged

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754ac5ff108326ac0d2372c12ceb95