### PR TITLE
Add artist detail view

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/adapters/ArtistHeaderBinder.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/adapters/ArtistHeaderBinder.kt
@@ -1,0 +1,43 @@
+package org.moire.ultrasonic.adapters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.drakeet.multitype.ItemViewBinder
+import org.moire.ultrasonic.R
+import org.moire.ultrasonic.domain.Identifiable
+
+/** Binder for displaying artist information in the header section */
+class ArtistHeaderBinder(
+    private val onPlayAll: () -> Unit
+) : ItemViewBinder<ArtistHeaderBinder.ArtistHeader, ArtistHeaderBinder.ViewHolder>() {
+
+    override fun onCreateViewHolder(inflater: LayoutInflater, parent: ViewGroup): ViewHolder {
+        return ViewHolder(inflater.inflate(R.layout.list_header_artist_detail, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, item: ArtistHeader) {
+        holder.title.text = item.name
+        holder.genres.text = item.genres
+        holder.description.text = item.description
+        holder.playAll.setOnClickListener { onPlayAll() }
+    }
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val title: TextView = view.findViewById(R.id.artist_title)
+        val genres: TextView = view.findViewById(R.id.artist_genres)
+        val description: TextView = view.findViewById(R.id.artist_description)
+        val playAll: Button = view.findViewById(R.id.artist_play_all)
+    }
+
+    data class ArtistHeader(
+        val name: String,
+        val genres: String?,
+        val description: String?
+    ) : Identifiable {
+        override val id: String = "artist_header"
+    }
+}

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/adapters/TextDividerBinder.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/adapters/TextDividerBinder.kt
@@ -1,0 +1,29 @@
+package org.moire.ultrasonic.adapters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.drakeet.multitype.ItemViewBinder
+import org.moire.ultrasonic.R
+import org.moire.ultrasonic.domain.Identifiable
+
+/** Binder for simple divider rows with dynamic text */
+class TextDividerBinder : ItemViewBinder<TextDividerBinder.TextDivider, TextDividerBinder.ViewHolder>() {
+    override fun onCreateViewHolder(inflater: LayoutInflater, parent: ViewGroup): ViewHolder {
+        return ViewHolder(inflater.inflate(R.layout.list_item_divider, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, item: TextDivider) {
+        holder.textView.text = item.text
+    }
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val textView: TextView = view.findViewById(R.id.text)
+    }
+
+    data class TextDivider(val text: String) : Identifiable {
+        override val id: String get() = "text_divider_$text"
+    }
+}

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistDetailFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistDetailFragment.kt
@@ -1,0 +1,151 @@
+package org.moire.ultrasonic.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.androidx.scope.ScopeFragment
+import org.koin.core.component.inject
+import org.moire.ultrasonic.NavigationGraphDirections
+import org.moire.ultrasonic.R
+import org.moire.ultrasonic.adapters.AlbumRowDelegate
+import org.moire.ultrasonic.adapters.ArtistHeaderBinder
+import org.moire.ultrasonic.adapters.BaseAdapter
+import org.moire.ultrasonic.adapters.TextDividerBinder
+import org.moire.ultrasonic.domain.Album
+import org.moire.ultrasonic.domain.Identifiable
+import org.moire.ultrasonic.service.MediaPlayerManager
+import org.moire.ultrasonic.service.MusicServiceFactory
+import org.moire.ultrasonic.util.toastingExceptionHandler
+
+/**
+ * Detailed view for an artist showing discography grouped by release type and year.
+ */
+class ArtistDetailFragment : ScopeFragment() {
+
+    private val args: ArtistDetailFragmentArgs by navArgs()
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var swipeRefresh: SwipeRefreshLayout
+
+    private val mediaPlayerManager: MediaPlayerManager by inject()
+
+    private val headerAdapter = BaseAdapter<Identifiable>()
+    private val albumAdapter = BaseAdapter<Identifiable>()
+    private val epAdapter = BaseAdapter<Identifiable>()
+    private val singleAdapter = BaseAdapter<Identifiable>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_artist_detail, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        swipeRefresh = view.findViewById(R.id.swipe_refresh_view)
+        recyclerView = view.findViewById(R.id.recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+
+        headerAdapter.register(ArtistHeaderBinder { playAll() })
+        albumAdapter.register(TextDividerBinder())
+        albumAdapter.register(AlbumRowDelegate(::onAlbumClick) { _: MenuItem, _: Album -> false })
+        epAdapter.register(TextDividerBinder())
+        epAdapter.register(AlbumRowDelegate(::onAlbumClick) { _: MenuItem, _: Album -> false })
+        singleAdapter.register(TextDividerBinder())
+        singleAdapter.register(AlbumRowDelegate(::onAlbumClick) { _: MenuItem, _: Album -> false })
+
+        recyclerView.adapter = ConcatAdapter(headerAdapter, albumAdapter, epAdapter, singleAdapter)
+
+        swipeRefresh.setOnRefreshListener { loadData() }
+        loadData()
+    }
+
+    private fun playAll() {
+        mediaPlayerManager.playTracksAndToast(
+            fragment = this,
+            insertionMode = MediaPlayerManager.InsertionMode.CLEAR,
+            id = args.artistId,
+            isArtist = true
+        )
+    }
+
+    private fun onAlbumClick(album: Album) {
+        val action = NavigationGraphDirections.toTrackCollection(
+            id = album.id,
+            isAlbum = album.isDirectory,
+            name = album.title,
+            parentId = album.parent
+        )
+        findNavController().navigate(action)
+    }
+
+    private fun loadData() {
+        viewLifecycleOwner.lifecycleScope.launch(toastingExceptionHandler()) {
+            swipeRefresh.isRefreshing = true
+            val service = MusicServiceFactory.getMusicService()
+            val albums = withContext(Dispatchers.IO) {
+                service.getAlbumsOfArtist(args.artistId, null, true)
+            }
+            swipeRefresh.isRefreshing = false
+            updateAdapters(albums)
+        }
+    }
+
+    private fun updateAdapters(albums: List<Album>) {
+        val name = albums.firstOrNull()?.artist ?: ""
+        val genres = albums.flatMap { it.genres ?: listOfNotNull(it.genre) }
+            .distinct().joinToString(", ")
+        val header = ArtistHeaderBinder.ArtistHeader(name, genres.ifBlank { null }, null)
+        headerAdapter.submitList(listOf(header))
+
+        albumAdapter.submitList(buildSection(getString(R.string.search_albums)) { album ->
+            val title = album.title ?: ""
+            !title.contains("EP", true) && !title.contains("single", true)
+        }.invoke(albums))
+
+        epAdapter.submitList(buildSection(getString(R.string.artist_detail_eps)) { album ->
+            album.title?.contains("EP", true) == true
+        }.invoke(albums))
+
+        singleAdapter.submitList(buildSection(getString(R.string.artist_detail_singles)) { album ->
+            album.title?.contains("single", true) == true
+        }.invoke(albums))
+    }
+
+    private fun buildSection(title: String, filter: (Album) -> Boolean): (List<Album>) -> List<Identifiable> {
+        return { all ->
+            val subset = all.filter(filter)
+            if (subset.isEmpty()) emptyList() else {
+                val items = mutableListOf<Identifiable>()
+                items.add(TextDividerBinder.TextDivider(title))
+                val sorted = subset.sortedWith(
+                    compareByDescending<Album> { it.year ?: 0 }.thenBy { it.title }
+                )
+                var currentYear: Int? = null
+                for (album in sorted) {
+                    val year = album.year
+                    if (year != null && year != currentYear) {
+                        currentYear = year
+                        items.add(TextDividerBinder.TextDivider(year.toString()))
+                    }
+                    items.add(album)
+                }
+                items
+            }
+        }
+    }
+}

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListFragment.kt
@@ -18,7 +18,6 @@ import androidx.recyclerview.widget.RecyclerView
 import org.moire.ultrasonic.NavigationGraphDirections
 import org.moire.ultrasonic.R
 import org.moire.ultrasonic.adapters.ArtistRowBinder
-import org.moire.ultrasonic.api.subsonic.models.AlbumListType
 import org.moire.ultrasonic.domain.Artist
 import org.moire.ultrasonic.domain.ArtistOrIndex
 import org.moire.ultrasonic.domain.Index
@@ -97,13 +96,8 @@ class ArtistListFragment : EntryListFragment<ArtistOrIndex>() {
                 isArtist = (item is Artist)
             )
         } else {
-            NavigationGraphDirections.toAlbumList(
-                type = AlbumListType.SORTED_BY_NAME,
-                byArtist = true,
-                id = item.id,
-                title = item.name,
-                size = 1000,
-                offset = 0
+            NavigationGraphDirections.toArtistDetail(
+                artistId = item.id
             )
         }
 

--- a/ultrasonic/src/main/res/layout/fragment_artist_detail.xml
+++ b/ultrasonic/src/main/res/layout/fragment_artist_detail.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/list_parts_empty_view" />
+    <include layout="@layout/list_parts_recycler" />
+
+</LinearLayout>

--- a/ultrasonic/src/main/res/layout/list_header_artist_detail.xml
+++ b/ultrasonic/src/main/res/layout/list_header_artist_detail.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/artist_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceHeadline6" />
+
+    <TextView
+        android:id="@+id/artist_genres"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="4dp"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    <TextView
+        android:id="@+id/artist_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="4dp"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    <Button
+        android:id="@+id/artist_play_all"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/select_album.play_all"
+        android:layout_marginTop="8dp" />
+</LinearLayout>

--- a/ultrasonic/src/main/res/navigation/navigation_graph.xml
+++ b/ultrasonic/src/main/res/navigation/navigation_graph.xml
@@ -20,6 +20,9 @@
         android:id="@+id/toArtistList"
         app:destination="@id/artistListFragment" />
     <action
+        android:id="@+id/toArtistDetail"
+        app:destination="@id/artistDetailFragment" />
+    <action
         android:id="@+id/toSongList"
         app:destination="@id/selectSongFragment" />
     <action
@@ -58,6 +61,13 @@
             android:defaultValue="@null"
             app:argType="string"
             app:nullable="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/artistDetailFragment"
+        android:name="org.moire.ultrasonic.fragment.ArtistDetailFragment">
+        <argument
+            android:name="artistId"
+            app:argType="string" />
     </fragment>
     <fragment
         android:id="@+id/trackCollectionFragment"

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -178,6 +178,8 @@
     <string name="select_album.no_network">Warning: No usable network available.\n If you are using mobile data, you may need to allow downloads on metered connections in the settings.</string>
     <string name="select_album.no_sdcard">Error: No SD card available.</string>
     <string name="select_album.play_all">Play All</string>
+    <string name="artist_detail_eps">EPs</string>
+    <string name="artist_detail_singles">Singles</string>
     <string name="select_artist.all_folders">All Folders</string>
     <string name="select_artist.folder">Select Folder</string>
     <string name="select_genre.empty">No genres found</string>


### PR DESCRIPTION
## Summary
- add `ArtistDetailFragment` to show artist info and discography
- create supporting adapters and layouts
- link fragment in navigation graph
- navigate to new detail screen from artist list

## Testing
- `./gradlew -Pqc ktlintCheck detekt`

------
https://chatgpt.com/codex/tasks/task_e_6878abe960388326b91f1e1d318c3c0d