### PR TITLE
Add artist genre fields and DB migration

### DIFF
--- a/core/domain/src/main/kotlin/org/moire/ultrasonic/domain/Artist.kt
+++ b/core/domain/src/main/kotlin/org/moire/ultrasonic/domain/Artist.kt
@@ -10,6 +10,12 @@ package org.moire.ultrasonic.domain
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 
+/**
+ * Represents an artist which can optionally contain genre information and a
+ * textual description. The list of genres is stored using Room's
+ * {@link Converters} which serialises lists as JSON strings.
+ */
+
 @Entity(tableName = "artists", primaryKeys = ["id", "serverId"])
 data class Artist(
     override var id: String,
@@ -19,5 +25,8 @@ data class Artist(
     override var index: String? = null,
     override var coverArt: String? = null,
     override var albumCount: Long? = null,
+    var genre: String? = null,
+    var genres: List<String>? = null,
+    var description: String? = null,
     override var closeness: Int = 0
 ) : ArtistOrIndex(id, serverId)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
@@ -166,6 +166,7 @@ class ActiveServerProvider(
         )
             .addMigrations(META_MIGRATION_2_3)
             .addMigrations(META_MIGRATION_3_4)
+            .addMigrations(META_MIGRATION_4_5)
             .fallbackToDestructiveMigrationOnDowngrade()
             .build()
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/MetaDatabase.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/MetaDatabase.kt
@@ -44,7 +44,7 @@ import org.moire.ultrasonic.domain.Track
         )
     ],
     exportSchema = true,
-    version = 4
+    version = 5
 )
 @TypeConverters(Converters::class)
 abstract class MetaDatabase : RoomDatabase() {
@@ -95,7 +95,7 @@ val META_MIGRATION_2_3: Migration = object : Migration(2, 3) {
             "CREATE TABLE IF NOT EXISTS `indexes` (`id` TEXT NOT NULL, `serverId` INTEGER NOT NULL DEFAULT -1, `name` TEXT, `index` TEXT, `coverArt` TEXT, `albumCount` INTEGER, `closeness` INTEGER NOT NULL, `musicFolderId` TEXT, PRIMARY KEY(`id`, `serverId`))"
         )
         db.execSQL(
-            "CREATE TABLE IF NOT EXISTS `artists` (`id` TEXT NOT NULL, `serverId` INTEGER NOT NULL DEFAULT -1, `name` TEXT, `index` TEXT, `coverArt` TEXT, `albumCount` INTEGER, `closeness` INTEGER NOT NULL, PRIMARY KEY(`id`, `serverId`))"
+            "CREATE TABLE IF NOT EXISTS `artists` (`id` TEXT NOT NULL, `serverId` INTEGER NOT NULL DEFAULT -1, `name` TEXT, `index` TEXT, `coverArt` TEXT, `albumCount` INTEGER, `genre` TEXT, `genres` TEXT, `description` TEXT, `closeness` INTEGER NOT NULL, PRIMARY KEY(`id`, `serverId`))"
         )
         db.execSQL(
             "CREATE TABLE IF NOT EXISTS `music_folders` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `serverId` INTEGER NOT NULL DEFAULT -1, PRIMARY KEY(`id`, `serverId`))"
@@ -111,5 +111,13 @@ val META_MIGRATION_3_4: Migration = object : Migration(3, 4) {
         db.execSQL("ALTER TABLE `tracks` ADD COLUMN `date` TEXT")
         db.execSQL("ALTER TABLE `albums` ADD COLUMN `genres` TEXT")
         db.execSQL("ALTER TABLE `albums` ADD COLUMN `date` TEXT")
+    }
+}
+
+val META_MIGRATION_4_5: Migration = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `genre` TEXT")
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `genres` TEXT")
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `description` TEXT")
     }
 }


### PR DESCRIPTION
## Summary
- expand Artist entity to store genre, genres, and description
- update MetaDatabase to version 5 and migrate existing tables
- include new migration in database initialization

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878abe9d4248326b5bf77b1d9746df2