### PR TITLE
Add album type helpers

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/domain/AlbumExtensions.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/domain/AlbumExtensions.kt
@@ -1,0 +1,22 @@
+package org.moire.ultrasonic.domain
+
+/**
+ * Helper extension functions for [Album] classification.
+ */
+
+private const val EP_MAX_TRACKS = 6
+private const val EP_MAX_DURATION_SECONDS = 30 * 60
+
+/** Returns true if this album should be treated as an EP. */
+fun Album.isEP(): Boolean {
+    val tracks = this.songCount ?: return false
+    val totalDuration = this.duration ?: 0
+    return tracks <= EP_MAX_TRACKS && totalDuration < EP_MAX_DURATION_SECONDS
+}
+
+/** Returns true if this album consists of exactly one track. */
+fun Album.isSingle(): Boolean {
+    val tracks = this.songCount ?: return false
+    return tracks == 1L
+}
+

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistDetailFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistDetailFragment.kt
@@ -1,0 +1,32 @@
+package org.moire.ultrasonic.fragment
+
+import androidx.fragment.app.Fragment
+import org.moire.ultrasonic.domain.Album
+import org.moire.ultrasonic.domain.isEP
+import org.moire.ultrasonic.domain.isSingle
+
+/**
+ * Fragment showing details for a single artist including discography lists.
+ * This implementation is minimal and focuses on separating albums by type.
+ */
+class ArtistDetailFragment : Fragment() {
+
+    /**
+     * Splits a list of [Album]s into albums, EPs and singles.
+     */
+    fun splitDiscography(albums: List<Album>): Triple<List<Album>, List<Album>, List<Album>> {
+        val fullAlbums = mutableListOf<Album>()
+        val eps = mutableListOf<Album>()
+        val singles = mutableListOf<Album>()
+
+        albums.forEach { album ->
+            when {
+                album.isSingle() -> singles += album
+                album.isEP() -> eps += album
+                else -> fullAlbums += album
+            }
+        }
+        return Triple(fullAlbums, eps, singles)
+    }
+}
+

--- a/ultrasonic/src/test/kotlin/org/moire/ultrasonic/domain/AlbumExtensionsTest.kt
+++ b/ultrasonic/src/test/kotlin/org/moire/ultrasonic/domain/AlbumExtensionsTest.kt
@@ -1,0 +1,40 @@
+package org.moire.ultrasonic.domain
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+
+/** Tests for [Album.isEP] and [Album.isSingle]. */
+class AlbumExtensionsTest {
+    @Test
+    fun `should identify EP`() {
+        val album = Album(
+            id = "1",
+            songCount = 6,
+            duration = 29 * 60,
+        )
+        album.isEP() `should be equal to` true
+    }
+
+    @Test
+    fun `should identify non EP when too long`() {
+        val album = Album(
+            id = "2",
+            songCount = 6,
+            duration = 31 * 60,
+        )
+        album.isEP() `should be equal to` false
+    }
+
+    @Test
+    fun `should identify single`() {
+        val album = Album(id = "3", songCount = 1, duration = 200)
+        album.isSingle() `should be equal to` true
+    }
+
+    @Test
+    fun `should not treat multi-track album as single`() {
+        val album = Album(id = "4", songCount = 2, duration = 400)
+        album.isSingle() `should be equal to` false
+    }
+}
+


### PR DESCRIPTION
## Summary
- add extension functions `isEP()` and `isSingle()` for Album
- provide minimal `ArtistDetailFragment` using these helpers
- test Album extension helpers

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878abea3e448326883b006a24c0cf51