### PR TITLE
Add artist info retrieval

### DIFF
--- a/core/domain/src/main/kotlin/org/moire/ultrasonic/domain/Artist.kt
+++ b/core/domain/src/main/kotlin/org/moire/ultrasonic/domain/Artist.kt
@@ -19,5 +19,7 @@ data class Artist(
     override var index: String? = null,
     override var coverArt: String? = null,
     override var albumCount: Long? = null,
-    override var closeness: Int = 0
+    override var closeness: Int = 0,
+    var genre: String? = null,
+    var description: String? = null
 ) : ArtistOrIndex(id, serverId)

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/ApiVersionCheckWrapper.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/ApiVersionCheckWrapper.kt
@@ -30,6 +30,7 @@ import org.moire.ultrasonic.api.subsonic.response.GetAlbumResponse
 import org.moire.ultrasonic.api.subsonic.response.GetArtistResponse
 import org.moire.ultrasonic.api.subsonic.response.GetArtistsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetLyricsResponse
+import org.moire.ultrasonic.api.subsonic.response.GetArtistInfo2Response
 import org.moire.ultrasonic.api.subsonic.response.GetPlaylistsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetPodcastsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetRandomSongsResponse
@@ -81,6 +82,15 @@ internal class ApiVersionCheckWrapper(
     override fun getArtist(id: String): Call<GetArtistResponse> {
         checkVersion(V1_8_0)
         return api.getArtist(id)
+    }
+
+    override fun getArtistInfo2(
+        id: String,
+        count: Int?,
+        includeNotPresent: Boolean?
+    ): Call<GetArtistInfo2Response> {
+        checkVersion(V1_11_0)
+        return api.getArtistInfo2(id, count, includeNotPresent)
     }
 
     override fun getAlbum(id: String): Call<GetAlbumResponse> {

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIDefinition.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIDefinition.kt
@@ -18,6 +18,7 @@ import org.moire.ultrasonic.api.subsonic.response.GetAlbumListResponse
 import org.moire.ultrasonic.api.subsonic.response.GetAlbumResponse
 import org.moire.ultrasonic.api.subsonic.response.GetArtistResponse
 import org.moire.ultrasonic.api.subsonic.response.GetArtistsResponse
+import org.moire.ultrasonic.api.subsonic.response.GetArtistInfo2Response
 import org.moire.ultrasonic.api.subsonic.response.GetIndexesResponse
 import org.moire.ultrasonic.api.subsonic.response.GetLyricsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetMusicDirectoryResponse
@@ -105,6 +106,13 @@ interface SubsonicAPIDefinition {
 
     @GET("getArtist.view")
     fun getArtist(@Query("id") id: String): Call<GetArtistResponse>
+
+    @GET("getArtistInfo2.view")
+    fun getArtistInfo2(
+        @Query("id") id: String,
+        @Query("count") count: Int? = null,
+        @Query("includeNotPresent") includeNotPresent: Boolean? = null
+    ): Call<GetArtistInfo2Response>
 
     @GET("getAlbum.view")
     fun getAlbum(@Query("id") id: String): Call<GetAlbumResponse>

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/models/ArtistInfo.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/models/ArtistInfo.kt
@@ -1,0 +1,12 @@
+package org.moire.ultrasonic.api.subsonic.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Additional information for an artist provided by the Subsonic API.
+ */
+data class ArtistInfo(
+    val biography: String? = null,
+    val genre: String? = null,
+    @JsonProperty("similarArtist") val similarArtists: List<Artist> = emptyList()
+)

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/response/GetArtistInfo2Response.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/response/GetArtistInfo2Response.kt
@@ -1,0 +1,16 @@
+package org.moire.ultrasonic.api.subsonic.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions
+import org.moire.ultrasonic.api.subsonic.SubsonicError
+import org.moire.ultrasonic.api.subsonic.models.ArtistInfo
+
+/**
+ * Response wrapper for the getArtistInfo2 API call.
+ */
+class GetArtistInfo2Response(
+    status: Status,
+    version: SubsonicAPIVersions,
+    error: SubsonicError?,
+    @JsonProperty("artistInfo2") val artistInfo: ArtistInfo = ArtistInfo(),
+) : SubsonicResponse(status, version, error)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
@@ -166,6 +166,7 @@ class ActiveServerProvider(
         )
             .addMigrations(META_MIGRATION_2_3)
             .addMigrations(META_MIGRATION_3_4)
+            .addMigrations(META_MIGRATION_4_5)
             .fallbackToDestructiveMigrationOnDowngrade()
             .build()
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/MetaDatabase.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/MetaDatabase.kt
@@ -44,7 +44,7 @@ import org.moire.ultrasonic.domain.Track
         )
     ],
     exportSchema = true,
-    version = 4
+    version = 5
 )
 @TypeConverters(Converters::class)
 abstract class MetaDatabase : RoomDatabase() {
@@ -111,5 +111,12 @@ val META_MIGRATION_3_4: Migration = object : Migration(3, 4) {
         db.execSQL("ALTER TABLE `tracks` ADD COLUMN `date` TEXT")
         db.execSQL("ALTER TABLE `albums` ADD COLUMN `genres` TEXT")
         db.execSQL("ALTER TABLE `albums` ADD COLUMN `date` TEXT")
+    }
+}
+
+val META_MIGRATION_4_5: Migration = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `genre` TEXT")
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `description` TEXT")
     }
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/CachedMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/CachedMusicService.kt
@@ -157,6 +157,11 @@ class CachedMusicService(private val musicService: MusicService) : MusicService,
     }
 
     @Throws(Exception::class)
+    override fun getArtistInfo(id: String): Artist? {
+        return musicService.getArtistInfo(id)
+    }
+
+    @Throws(Exception::class)
     override fun getMusicDirectory(id: String, name: String?, refresh: Boolean): MusicDirectory {
         checkSettingsChanged()
         var cache = if (refresh) null else cachedMusicDirectories[id]

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadTask.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadTask.kt
@@ -282,9 +282,17 @@ class DownloadTask(
 //            }
 //        }
 
-        // If we have found an artist, cache it.
-        if (artist != null) {
-            offlineDB.artistDao().insert(artist)
+        // If we have found an artist, try to enrich it with additional info.
+        artist?.let { existing ->
+            try {
+                musicService.getArtistInfo(artistId)?.let { info ->
+                    if (existing.genre == null) existing.genre = info.genre
+                    if (existing.description == null) existing.description = info.description
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to fetch artist info")
+            }
+            offlineDB.artistDao().insert(existing)
         }
 
         return artist

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MusicService.kt
@@ -73,6 +73,9 @@ interface MusicService {
     fun getArtists(refresh: Boolean, offset: Int? = null, count: Int? = null): List<Artist>
 
     @Throws(Exception::class)
+    fun getArtistInfo(id: String): Artist?
+
+    @Throws(Exception::class)
     fun getMusicDirectory(id: String, name: String?, refresh: Boolean): MusicDirectory
 
     @Throws(Exception::class)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/OfflineMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/OfflineMusicService.kt
@@ -141,6 +141,11 @@ class OfflineMusicService : MusicService, KoinComponent {
         return cachedArtists.get()
     }
 
+    @Throws(OfflineException::class)
+    override fun getArtistInfo(id: String): Artist? {
+        throw OfflineException("Artist info not available in offline mode")
+    }
+
     /*
      * Especially when dealing with indexes, this method can return Albums, Entries or a mix of both!
      */

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -104,6 +104,22 @@ open class RESTMusicService(
     }
 
     @Throws(Exception::class)
+    override fun getArtistInfo(id: String): Artist? {
+        return try {
+            val response = API.getArtistInfo2(id, null, null).execute().throwOnFailure()
+            val info = response.body()!!.artistInfo
+            Artist(
+                id = id,
+                serverId = activeServerId,
+                genre = info.genre,
+                description = info.biography
+            )
+        } catch (e: ApiNotSupportedException) {
+            null
+        }
+    }
+
+    @Throws(Exception::class)
     override fun star(id: String?, albumId: String?, artistId: String?) {
         API.star(id, albumId, artistId).execute().throwOnFailure()
     }


### PR DESCRIPTION
## Summary
- extend Artist data class to hold genre and description
- support getArtistInfo2 REST call
- add migration for new Artist columns
- fetch and cache artist info when downloading metadata

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878abebbfa083268ea4536cf553cf3c