### PR TITLE
Add artist metadata columns

### DIFF
--- a/core/domain/src/main/kotlin/org/moire/ultrasonic/domain/Artist.kt
+++ b/core/domain/src/main/kotlin/org/moire/ultrasonic/domain/Artist.kt
@@ -19,5 +19,8 @@ data class Artist(
     override var index: String? = null,
     override var coverArt: String? = null,
     override var albumCount: Long? = null,
-    override var closeness: Int = 0
+    override var closeness: Int = 0,
+    var genre: String? = null,
+    var genres: List<String>? = null,
+    var description: String? = null
 ) : ArtistOrIndex(id, serverId)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
@@ -166,6 +166,7 @@ class ActiveServerProvider(
         )
             .addMigrations(META_MIGRATION_2_3)
             .addMigrations(META_MIGRATION_3_4)
+            .addMigrations(META_MIGRATION_4_5)
             .fallbackToDestructiveMigrationOnDowngrade()
             .build()
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/MetaDatabase.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/MetaDatabase.kt
@@ -44,7 +44,7 @@ import org.moire.ultrasonic.domain.Track
         )
     ],
     exportSchema = true,
-    version = 4
+    version = 5
 )
 @TypeConverters(Converters::class)
 abstract class MetaDatabase : RoomDatabase() {
@@ -111,5 +111,13 @@ val META_MIGRATION_3_4: Migration = object : Migration(3, 4) {
         db.execSQL("ALTER TABLE `tracks` ADD COLUMN `date` TEXT")
         db.execSQL("ALTER TABLE `albums` ADD COLUMN `genres` TEXT")
         db.execSQL("ALTER TABLE `albums` ADD COLUMN `date` TEXT")
+    }
+}
+
+val META_MIGRATION_4_5: Migration = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `genre` TEXT")
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `genres` TEXT")
+        db.execSQL("ALTER TABLE `artists` ADD COLUMN `description` TEXT")
     }
 }


### PR DESCRIPTION
## Summary
- add extra artist properties for genre, genres, and description
- migrate MetaDatabase from version 4 to 5 with new columns
- register META_MIGRATION_4_5 when building MetaDatabase

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878abeb23948326b28d79f15c76cde7