### PR TITLE
Add artist filtering to song discovery

### DIFF
--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/ApiVersionCheckWrapper.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/ApiVersionCheckWrapper.kt
@@ -11,6 +11,7 @@ import okhttp3.ResponseBody
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_11_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_12_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_14_0
+import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_16_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_2_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_3_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_4_0
@@ -19,7 +20,6 @@ import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_6_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_7_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_8_0
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_9_0
-import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions.V1_16_0
 import org.moire.ultrasonic.api.subsonic.models.AlbumListType
 import org.moire.ultrasonic.api.subsonic.models.JukeboxAction
 import org.moire.ultrasonic.api.subsonic.response.BookmarksResponse
@@ -28,10 +28,10 @@ import org.moire.ultrasonic.api.subsonic.response.GenresResponse
 import org.moire.ultrasonic.api.subsonic.response.GetAlbumList2Response
 import org.moire.ultrasonic.api.subsonic.response.GetAlbumListResponse
 import org.moire.ultrasonic.api.subsonic.response.GetAlbumResponse
+import org.moire.ultrasonic.api.subsonic.response.GetArtistInfo2Response
 import org.moire.ultrasonic.api.subsonic.response.GetArtistResponse
 import org.moire.ultrasonic.api.subsonic.response.GetArtistsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetLyricsResponse
-import org.moire.ultrasonic.api.subsonic.response.GetArtistInfo2Response
 import org.moire.ultrasonic.api.subsonic.response.GetPlaylistsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetPodcastsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetRandomSongsResponse

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIDefinition.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIDefinition.kt
@@ -16,9 +16,9 @@ import org.moire.ultrasonic.api.subsonic.response.GenresResponse
 import org.moire.ultrasonic.api.subsonic.response.GetAlbumList2Response
 import org.moire.ultrasonic.api.subsonic.response.GetAlbumListResponse
 import org.moire.ultrasonic.api.subsonic.response.GetAlbumResponse
+import org.moire.ultrasonic.api.subsonic.response.GetArtistInfo2Response
 import org.moire.ultrasonic.api.subsonic.response.GetArtistResponse
 import org.moire.ultrasonic.api.subsonic.response.GetArtistsResponse
-import org.moire.ultrasonic.api.subsonic.response.GetArtistInfo2Response
 import org.moire.ultrasonic.api.subsonic.response.GetIndexesResponse
 import org.moire.ultrasonic.api.subsonic.response.GetLyricsResponse
 import org.moire.ultrasonic.api.subsonic.response.GetMusicDirectoryResponse

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/response/GetArtistInfo2Response.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/response/GetArtistInfo2Response.kt
@@ -12,5 +12,5 @@ class GetArtistInfo2Response(
     status: Status,
     version: SubsonicAPIVersions,
     error: SubsonicError?,
-    @JsonProperty("artistInfo2") val artistInfo: ArtistInfo = ArtistInfo(),
+    @JsonProperty("artistInfo2") val artistInfo: ArtistInfo = ArtistInfo()
 ) : SubsonicResponse(status, version, error)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/TrackCollectionFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/TrackCollectionFragment.kt
@@ -527,6 +527,7 @@ open class TrackCollectionFragment(
         val shareId = navArgs.shareId
         val shareName = navArgs.shareName
         val genre = navArgs.genre
+        val artists = navArgs.artists?.filter { it.isNotBlank() } ?: emptyList()
         val festival = navArgs.festival
         val label = navArgs.label
         val songs = navArgs.songs
@@ -587,6 +588,13 @@ open class TrackCollectionFragment(
                         }
                         if (!festival.isNullOrBlank()) append(festival)
                         if (!label.isNullOrBlank()) append(label)
+                        if (artists.isNotEmpty()) {
+                            if (isNotEmpty()) append(" ")
+                            append(
+                                if (artists.size == 1) artists.first()
+                                else getString(R.string.common_artist)
+                            )
+                        }
                         if (!genre.isNullOrBlank() && genre != "All") {
                             if (isNotEmpty()) append(" ")
                             append(genre)
@@ -608,6 +616,12 @@ open class TrackCollectionFragment(
                         }
                         genre?.takeIf { it != "All" && it.isNotBlank() }?.let {
                             add(Filter("GENRE", it))
+                        }
+                        if (artists.isNotEmpty()) {
+                            add(
+                                if (artists.size == 1) Filter("ARTIST", artists.first())
+                                else Filter("ARTIST", artists)
+                            )
                         }
                         festival?.takeIf { it != "All" && it.isNotBlank() }?.let {
                             add(Filter("FESTIVAL", it))

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/FilterModalFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/FilterModalFragment.kt
@@ -35,6 +35,7 @@ class FilterModalFragment : BottomSheetDialogFragment() {
     private val filterOptionsViewModel: FilterOptionsViewModel by activityViewModels()
 
     private val selectedGenres = mutableListOf<String>()
+    private val selectedArtists = mutableListOf<String>()
     private val selectedYears = mutableListOf<String>()
     private val selectedLabels = mutableListOf<String>()
     private var selectedFestivalLineup: String? = null
@@ -183,51 +184,22 @@ class FilterModalFragment : BottomSheetDialogFragment() {
     }
 
     private fun observeFilterOptions() {
-        filterOptionsViewModel.genres.observe(viewLifecycleOwner) { genres ->
-            redrawAllChips(
-                genres,
-                filterOptionsViewModel.years.value,
-                filterOptionsViewModel.labels.value,
-                filterOptionsViewModel.lineups.value,
-                filterOptionsViewModel.festivals.value
-            )
-        }
-        filterOptionsViewModel.years.observe(viewLifecycleOwner) { years ->
-            redrawAllChips(
-                filterOptionsViewModel.genres.value,
-                years,
-                filterOptionsViewModel.labels.value,
-                filterOptionsViewModel.lineups.value,
-                filterOptionsViewModel.festivals.value
-            )
-        }
-        filterOptionsViewModel.labels.observe(viewLifecycleOwner) { labels ->
-            redrawAllChips(
-                filterOptionsViewModel.genres.value,
-                filterOptionsViewModel.years.value,
-                labels,
-                filterOptionsViewModel.lineups.value,
-                filterOptionsViewModel.festivals.value
-            )
-        }
-        filterOptionsViewModel.lineups.observe(viewLifecycleOwner) { lineups ->
-            redrawAllChips(
-                filterOptionsViewModel.genres.value,
-                filterOptionsViewModel.years.value,
-                filterOptionsViewModel.labels.value,
-                lineups,
-                filterOptionsViewModel.festivals.value
-            )
-        }
-        filterOptionsViewModel.festivals.observe(viewLifecycleOwner) { festivals ->
+        val redraw: () -> Unit = {
             redrawAllChips(
                 filterOptionsViewModel.genres.value,
                 filterOptionsViewModel.years.value,
                 filterOptionsViewModel.labels.value,
                 filterOptionsViewModel.lineups.value,
-                festivals
+                filterOptionsViewModel.festivals.value,
+                filterOptionsViewModel.artists.value
             )
         }
+        filterOptionsViewModel.genres.observe(viewLifecycleOwner) { redraw() }
+        filterOptionsViewModel.years.observe(viewLifecycleOwner) { redraw() }
+        filterOptionsViewModel.labels.observe(viewLifecycleOwner) { redraw() }
+        filterOptionsViewModel.lineups.observe(viewLifecycleOwner) { redraw() }
+        filterOptionsViewModel.festivals.observe(viewLifecycleOwner) { redraw() }
+        filterOptionsViewModel.artists.observe(viewLifecycleOwner) { redraw() }
         filterOptionsViewModel.favorite.observe(viewLifecycleOwner) { favorite ->
             binding.favoriteButton.isSelected = favorite
             val iconRes = if (favorite) R.drawable.ic_star_full else R.drawable.ic_star_hollow
@@ -240,7 +212,8 @@ class FilterModalFragment : BottomSheetDialogFragment() {
         years: List<String>?,
         labels: List<String>?,
         lineups: List<String>?,
-        festivals: List<String>?
+        festivals: List<String>?,
+        artists: List<String>?
     ) {
         val group = binding.addChipGroup
         group.removeAllViews()
@@ -255,7 +228,7 @@ class FilterModalFragment : BottomSheetDialogFragment() {
                 chip.text = value
                 chip.setOnCloseIconClickListener {
                     values.remove(value)
-                    redrawAllChips(genres, years, labels, lineups, festivals)
+                    redrawAllChips(genres, years, labels, lineups, festivals, artists)
                 }
                 group.addView(chip)
             }
@@ -277,7 +250,7 @@ class FilterModalFragment : BottomSheetDialogFragment() {
                             val result = allOptions.filterIndexed { index, _ -> checked[index] }
                             values.clear()
                             values.addAll(result)
-                            redrawAllChips(genres, years, labels, lineups, festivals)
+                            redrawAllChips(genres, years, labels, lineups, festivals, artists)
                         }
                         .setNegativeButton(android.R.string.cancel, null)
                         .show()
@@ -290,13 +263,14 @@ class FilterModalFragment : BottomSheetDialogFragment() {
         addSelectedChips(getString(R.string.genre), selectedGenres, genres)
 
         if (modalType == FilterModalType.SONG) {
+            addSelectedChips(getString(R.string.common_artist), selectedArtists, artists)
             addSelectedChips(getString(R.string.label), selectedLabels, labels)
             if (selectedFestivalLineup != null) {
                 val chip = layoutInflater.inflate(R.layout.tsshadow_chip, group, false) as Chip
                 chip.text = selectedFestivalLineup
                 chip.setOnCloseIconClickListener {
                     selectedFestivalLineup = null
-                    redrawAllChips(genres, years, labels, lineups, festivals)
+                    redrawAllChips(genres, years, labels, lineups, festivals, artists)
                 }
                 group.addView(chip)
             } else if (lineups != null) {
@@ -308,7 +282,7 @@ class FilterModalFragment : BottomSheetDialogFragment() {
                         .setTitle("Select ${getString(R.string.festival_lineup)}")
                         .setItems(lineups.toTypedArray()) { _, which ->
                             selectedFestivalLineup = lineups[which]
-                            redrawAllChips(genres, years, labels, lineups, festivals)
+                            redrawAllChips(genres, years, labels, lineups, festivals, artists)
                         }
                         .show()
                 }
@@ -325,6 +299,7 @@ class FilterModalFragment : BottomSheetDialogFragment() {
         val filters = arguments?.getParcelable(ARG_INITIAL_FILTERS, FilterState::class.java) ?: return
         binding.selectTitle.setText(filters.title)
         selectedGenres.addAll(filters.genres)
+        selectedArtists.addAll(filters.artists)
         selectedYears.addAll(filters.years)
         selectedLabels.addAll(filters.label)
         selectedFestivalLineup = filters.festivalLineup
@@ -354,6 +329,7 @@ class FilterModalFragment : BottomSheetDialogFragment() {
     private fun collectFilterState(): FilterState = FilterState(
         title = binding.selectTitle.text.toString().trim(),
         genres = selectedGenres,
+        artists = selectedArtists,
         years = selectedYears,
         count = selectedResultCount,
         ratingMin = binding.selectRatingMin.selectedItem as Int,

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/FilterOptionsViewModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/FilterOptionsViewModel.kt
@@ -3,6 +3,7 @@ import androidx.lifecycle.MutableLiveData
 
 class FilterOptionsViewModel : ViewModel() {
     val genres = MutableLiveData<List<String>>()
+    val artists = MutableLiveData<List<String>>()
     val years = MutableLiveData<List<String>>()
     val labels = MutableLiveData<List<String>>()
     val festivals = MutableLiveData<List<String>>()

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/FilterState.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/FilterState.kt
@@ -5,6 +5,7 @@ import kotlinx.parcelize.Parcelize
 data class FilterState(
     val title: String = "",
     val genres: List<String> = emptyList(),
+    val artists: List<String> = emptyList(),
     val years: List<String> = emptyList(),
     val count: Int = 25,
     val ratingMin: Int = 0,

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/SelectFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/SelectFragment.kt
@@ -31,6 +31,7 @@ import org.moire.ultrasonic.service.MusicServiceFactory.getMusicService
 import org.moire.ultrasonic.data.ActiveServerProvider.Companion.isOffline
 import org.moire.ultrasonic.domain.Tag
 import org.moire.ultrasonic.util.toastingExceptionHandler
+import java.util.Locale
 import timber.log.Timber
 
 abstract class SelectFragment : Fragment(), RefreshableFragment, TileAdapterCallback {
@@ -110,6 +111,8 @@ abstract class SelectFragment : Fragment(), RefreshableFragment, TileAdapterCall
                     val filters = Filters().apply {
                         if (filterState.genres.isNotEmpty())
                             add(Filter("GENRE", filterState.genres))
+                        if (filterState.artists.isNotEmpty())
+                            add(Filter("ARTIST", filterState.artists))
                         if (filterState.years.isNotEmpty())
                             add(Filter("YEAR", filterState.years))
                         if (filterState.label.isNotEmpty())
@@ -164,6 +167,7 @@ abstract class SelectFragment : Fragment(), RefreshableFragment, TileAdapterCall
         return TileInfo(
             title = state.title,
             genre = state.genres,
+            artists = state.artists,
             year = state.years,
             label = state.label,
             festival = state.festival,
@@ -182,6 +186,7 @@ abstract class SelectFragment : Fragment(), RefreshableFragment, TileAdapterCall
         val filterState = FilterState(
             title = tile.title,
             genres = tile.genre ?: emptyList(),
+            artists = tile.artists ?: emptyList(),
             years = tile.year ?: emptyList(),
             label = tile.label ?: emptyList(),
             festivalLineup = tile.festivalLineup,
@@ -271,12 +276,22 @@ abstract class SelectFragment : Fragment(), RefreshableFragment, TileAdapterCall
                 musicService.getLineups(refresh)
             }.map { it.name }.sorted()
 
+            val artists = withContext(Dispatchers.IO) {
+                musicService.getArtists(refresh, null, null)
+            }.mapNotNull { it.name?.takeIf(String::isNotBlank) }
+                .distinctBy { it.lowercase(Locale.ROOT) }
+                .sortedWith(String.CASE_INSENSITIVE_ORDER)
+
             filterOptionsViewModel.genres.postValue(genres)
             filterOptionsViewModel.years.postValue(years)
             filterOptionsViewModel.labels.postValue(labels)
             filterOptionsViewModel.festivals.postValue(festivals)
             filterOptionsViewModel.lineups.postValue(lineups)
-            Timber.d("Filter data loaded: genres=${genres.size}, years=${years.size}, labels=${labels.size}, festivals=${festivals.size}")
+            filterOptionsViewModel.artists.postValue(artists)
+            Timber.d(
+                "Filter data loaded: genres=${genres.size}, years=${years.size}, " +
+                    "labels=${labels.size}, festivals=${festivals.size}, artists=${artists.size}"
+            )
         }
         swipeRefresh?.isRefreshing = false
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/TileInfo.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/tsshadow/TileInfo.kt
@@ -55,6 +55,7 @@ val genreIconMap: Map<String, Int> = mapOf(
 class TileInfo(
     var title: String = "",
     val genre: List<String>? = null,
+    val artists: List<String>? = null,
     val year: List<String>? = null,
     val size: Int = maxSongs,
     val festival: List<String>? = null,
@@ -85,7 +86,7 @@ class TileInfo(
                     ?.takeIf { it.isNotEmpty() }
                     ?.let { if (it.size == 1) it.first() else "Multiple" }
 
-            listOfNotNull(pick(festival), pick(label), pick(genre))
+            listOfNotNull(pick(artists), pick(festival), pick(label), pick(genre))
                 .joinToString(" ")
                 .let { if (it.isNotBlank()) append(it) }
 
@@ -102,6 +103,13 @@ fun navigateToGenre(tile: TileInfo): NavDirections {
         ?.takeIf { it.isNotEmpty() }
         ?.let {
             filters.add(if (it.size == 1) Filter("GENRE", it[0]) else Filter("GENRE", it))
+        }
+
+    tile.artists
+        ?.filter { it.isNotBlank() && it != "All" }
+        ?.takeIf { it.isNotEmpty() }
+        ?.let {
+            filters.add(if (it.size == 1) Filter("ARTIST", it[0]) else Filter("ARTIST", it))
         }
 
     tile.year

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/OfflineMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/OfflineMusicService.kt
@@ -450,6 +450,18 @@ class OfflineMusicService : MusicService, KoinComponent {
                         values.any { value -> genres.any { g -> g.equals(value, true) } }
                     }
                 }
+                "ARTIST" -> {
+                    val values = if (filter.value is Collection<*>) {
+                        (filter.value as Collection<*>).mapNotNull { it?.toString()?.takeIf(String::isNotBlank) }
+                    } else listOf(filter.value.toString())
+                    if (values.isNotEmpty()) {
+                        val normalized = values.map { it.lowercase(Locale.ROOT) }
+                        list = list.filter { track ->
+                            val artistName = track.artist?.lowercase(Locale.ROOT)
+                            artistName != null && normalized.any { it == artistName }
+                        }
+                    }
+                }
                 "YEAR" -> {
                     val years = if (filter.value is Collection<*>) {
                         (filter.value as Collection<*>).mapNotNull { it.toString().toIntOrNull() }

--- a/ultrasonic/src/main/res/navigation/navigation_graph.xml
+++ b/ultrasonic/src/main/res/navigation/navigation_graph.xml
@@ -155,6 +155,11 @@
             app:argType="string"
             app:nullable="true" />
         <argument
+            android:name="artists"
+            android:defaultValue="@null"
+            app:argType="string[]"
+            app:nullable="true" />
+        <argument
             android:name="festival"
             android:defaultValue="@null"
             app:argType="string"


### PR DESCRIPTION
## Summary
- add artist selections to filter state, modal UI, and filter option loading
- persist artist choices on tiles and include them when constructing song filters
- respect ARTIST filters in TrackCollection fallback routing and the offline music service

## Testing
- ./gradlew :ultrasonic:lintDebug *(fails: Android SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce87b2f9248326b1ce6e4865d8b70c